### PR TITLE
chore: fs-extra as dependency

### DIFF
--- a/packages/vite-plugin-use-wasm/package.json
+++ b/packages/vite-plugin-use-wasm/package.json
@@ -46,11 +46,11 @@
     "vite": ">=7.0.0"
   },
   "dependencies": {
-    "assemblyscript": "^0.28.6"
+    "assemblyscript": "^0.28.6",
+    "fs-extra": "^11.3.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
-    "fs-extra": "^11.3.1",
     "tsdown": "^0.15.0",
     "vite": "^7.1.5",
     "vitest": "^3.2.4"

--- a/packages/vite-plugin-use-wasm/tsdown.config.ts
+++ b/packages/vite-plugin-use-wasm/tsdown.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   format: "esm",
   sourcemap: true,
   target: "esnext",
-  external: ["vite", "assemblyscript", "fs-extra"],
+  external: ["assemblyscript"],
   copy: [
     {
       from: "src/types/assemblyscript.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,13 +63,13 @@ importers:
       assemblyscript:
         specifier: ^0.28.6
         version: 0.28.7
+      fs-extra:
+        specifier: ^11.3.1
+        version: 11.3.1
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
-      fs-extra:
-        specifier: ^11.3.1
-        version: 11.3.1
       tsdown:
         specifier: ^0.15.0
         version: 0.15.0(typescript@5.9.2)


### PR DESCRIPTION
This pull request updates how the `fs-extra` dependency is managed in the `vite-plugin-use-wasm` package. The main change is moving `fs-extra` from a development dependency to a regular dependency, and updating the external dependencies configuration accordingly.

**Dependency management:**

* Moved `fs-extra` from `devDependencies` to `dependencies` in `package.json`, ensuring it is available at runtime rather than just during development.
* Updated `pnpm-lock.yaml` to reflect the move of `fs-extra` to regular dependencies.

**Build configuration:**

* Removed `fs-extra` from the `external` array in `tsdown.config.ts`, so it will now be bundled or resolved differently during build.