### PR TITLE
feat: create adapter for browser support

### DIFF
--- a/packages/vite-plugin-use-wasm/src/constants/index.ts
+++ b/packages/vite-plugin-use-wasm/src/constants/index.ts
@@ -10,5 +10,8 @@ export const WASM_MODULE_DIRECTIVE = "use wasm";
 export const WASM_DIRECTIVE_REGEX = /^["']use wasm["'];?\s*/;
 export const BINDINGS_DEFAULT_WASM_URL_REGEX =
   /new URL\(".*?\.wasm", import\.meta\.url\)/g;
+export const STATIC_NODE_IMPORT_REGEX = /^import\s.+from\s+['"]node:[^'"]+['"];?\s*$/gm;
+export const NODE_BRANCH_REGEX = /const\s+isNodeOrBun\s*=.+?;\s*if\s*\(\s*isNodeOrBun\s*\)\s*\{\s*return\s+globalThis\.WebAssembly\.compile\([\s\S]*?import\(["']node:fs\/promises["']\)[\s\S]*?\);\s*\}\s*else\s*\{\s*return\s+await\s+globalThis\.WebAssembly\.compileStreaming\(globalThis\.fetch\(url\)\);\s*\}/ms;
+export const DYNAMIC_NODE_IMPORT_REGEX = /import\(["']node:[^"']+["']\)/g;
 
 export const STANDALONE_ENVIRONMENT_FOLDER = ".use-wasm-temp";

--- a/packages/vite-plugin-use-wasm/src/index.ts
+++ b/packages/vite-plugin-use-wasm/src/index.ts
@@ -16,6 +16,7 @@ import {
   WASM_TEXT_EXTENSION,
 } from "./constants";
 import { StandaloneEnvironment } from "./utils";
+import { adaptBindingsForBrowser } from "./utils/browser";
 
 interface AssemblyScriptOptions {
   optimize?: boolean;
@@ -107,23 +108,23 @@ export default function useWasm(options?: AssemblyScriptOptions): Plugin {
       await standaloneEnvironment.setup();
       const outFilePath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        wasmFileName,
+        wasmFileName
       );
       const textFilePath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        wasmTextFileName,
+        wasmTextFileName
       );
       const jsBindingsPath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        jsBindingsFileName,
+        jsBindingsFileName
       );
       const dTsPath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        dTsFileName,
+        dTsFileName
       );
       const sourceMapPath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        sourceMapFileName,
+        sourceMapFileName
       );
 
       const compilerOptions = [
@@ -155,7 +156,7 @@ export default function useWasm(options?: AssemblyScriptOptions): Plugin {
       } catch (error) {
         if (error instanceof Error) {
           throw new Error(
-            `AssemblyScript compilation failed: ${error.message}`,
+            `AssemblyScript compilation failed: ${error.message}`
           );
         }
       }
@@ -186,7 +187,7 @@ export default function useWasm(options?: AssemblyScriptOptions): Plugin {
 
         const devModeBindings = generatedBindings.replace(
           BINDINGS_DEFAULT_WASM_URL_REGEX,
-          `"${wasmDataUrl}"`,
+          `"${wasmDataUrl}"`
         );
 
         try {
@@ -227,9 +228,11 @@ export default function useWasm(options?: AssemblyScriptOptions): Plugin {
           this.warn("Not possible to clean standalone environment");
         }
 
-        const resolvedBindings = generatedBindings.replace(
+        const resolvedBindings = adaptBindingsForBrowser(
+          generatedBindings
+        ).replace(
           BINDINGS_DEFAULT_WASM_URL_REGEX,
-          `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`,
+          `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`
         );
         return {
           code: resolvedBindings,

--- a/packages/vite-plugin-use-wasm/src/utils/browser.ts
+++ b/packages/vite-plugin-use-wasm/src/utils/browser.ts
@@ -4,7 +4,7 @@ import {
   STATIC_NODE_IMPORT_REGEX,
 } from "../constants";
 
-export function sanitizeBindingsForBrowser(code: string): string {
+export function adaptBindingsForBrowser(code: string): string {
   let out = code.replace(STATIC_NODE_IMPORT_REGEX, "");
 
   out = out.replace(

--- a/packages/vite-plugin-use-wasm/src/utils/browser.ts
+++ b/packages/vite-plugin-use-wasm/src/utils/browser.ts
@@ -1,0 +1,28 @@
+import {
+  DYNAMIC_NODE_IMPORT_REGEX,
+  NODE_BRANCH_REGEX,
+  STATIC_NODE_IMPORT_REGEX,
+} from "../constants";
+
+export function sanitizeBindingsForBrowser(code: string): string {
+  let out = code.replace(STATIC_NODE_IMPORT_REGEX, "");
+
+  out = out.replace(
+    NODE_BRANCH_REGEX,
+    `return await (async () => {
+      if (globalThis.WebAssembly.compileStreaming) {
+        try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); } catch {}
+      }
+      const res = await globalThis.fetch(url);
+      const bytes = await res.arrayBuffer();
+      return await globalThis.WebAssembly.compile(bytes);
+    })()`
+  );
+
+  out = out.replace(
+    DYNAMIC_NODE_IMPORT_REGEX,
+    "Promise.reject(new Error('node: modules are unavailable in browser'))"
+  );
+
+  return out;
+}


### PR DESCRIPTION
This pull request enhances the browser compatibility of the `vite-plugin-use-wasm` package by introducing a new utility to adapt AssemblyScript-generated bindings for browser environments. The main change is the addition of the `adaptBindingsForBrowser` function, which removes or rewrites Node.js-specific code patterns in the generated bindings. Several new regular expressions are introduced to facilitate this adaptation. The plugin now uses this function to ensure that the generated bindings work correctly in browser contexts.

**Browser compatibility improvements:**

* Added `adaptBindingsForBrowser` utility in `utils/browser.ts` to rewrite or remove Node.js-specific imports and code branches from AssemblyScript-generated bindings, ensuring they work in browser environments.
* Updated the plugin logic in `index.ts` to use `adaptBindingsForBrowser` when processing generated bindings before returning them, replacing the previous direct replacement approach.

**Regular expression enhancements:**

* Introduced new regular expressions in `constants/index.ts` to match static and dynamic Node.js imports and Node.js-specific code branches, supporting the adaptation process.

**Minor refactoring and formatting:**

* Minor formatting adjustments in file path joining and error handling for improved readability and consistency in `index.ts`. [[1]](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L110-R127) [[2]](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L158-R159) [[3]](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L189-R190)
* Added import for the new browser adaptation utility in `index.ts`.