### PR TITLE
feat: add more options to customize the transformation

### DIFF
--- a/examples/react-vite-ts/vite.config.ts
+++ b/examples/react-vite-ts/vite.config.ts
@@ -7,5 +7,20 @@ import Inspect from "vite-plugin-inspect";
 import useWasm from "vite-plugin-use-wasm";
 
 export default defineConfig({
-  plugins: [useWasm(), Inspect(), tailwindcss(), react()],
+  plugins: [
+    useWasm({
+      browser: true,
+      emitWasmTextFile: true,
+      compilerOptions: {
+        optimize: true,
+        optimizeLevel: 3,
+        shrinkLevel: 0,
+        noAssert: true,
+        converge: true,
+      }
+    }),
+    Inspect(),
+    tailwindcss(),
+    react(),
+  ],
 });

--- a/packages/vite-plugin-use-wasm/src/index.ts
+++ b/packages/vite-plugin-use-wasm/src/index.ts
@@ -17,59 +17,8 @@ import {
 } from "./constants";
 import { StandaloneEnvironment } from "./utils";
 import { adaptBindingsForBrowser } from "./utils/browser";
-
-interface AssemblyScriptOptions {
-  optimize?: boolean;
-  runtime?: "incremental" | "minimal" | "stub";
-  exportRuntime?: boolean;
-  importMemory?: boolean;
-  initialMemory?: number;
-  maximumMemory?: number;
-  sharedMemory?: boolean;
-  debug?: boolean;
-}
-
-interface PluginOptions {
-  compilerOptions?: AssemblyScriptOptions;
-  browser?: boolean;
-  emitWasmTextFile?: boolean;
-  emitDtsFile?: boolean;
-  emitSourceMap?: boolean;
-}
-
-function getCompilerFlags(options: AssemblyScriptOptions): string[] {
-  const flags: string[] = [];
-
-  if (options.optimize) {
-    flags.push("--optimize");
-  }
-
-  if (options.runtime) {
-    flags.push("--runtime", options.runtime);
-  }
-
-  if (options.importMemory) {
-    flags.push("--importMemory");
-  }
-
-  if (options.initialMemory) {
-    flags.push("--initialMemory", options.initialMemory.toString());
-  }
-
-  if (options.maximumMemory) {
-    flags.push("--maximumMemory", options.maximumMemory.toString());
-  }
-
-  if (options.sharedMemory) {
-    flags.push("--sharedMemory");
-  }
-
-  if (options.debug) {
-    flags.push("--debug");
-  }
-
-  return flags;
-}
+import type { PluginOptions } from "./options";
+import { getCompilerFlags } from "./utils/compiler";
 
 export default function useWasm(options?: PluginOptions): Plugin {
   const {
@@ -148,6 +97,8 @@ export default function useWasm(options?: PluginOptions): Plugin {
         sourceMapFileName
       );
 
+      const userDefinedFlags =
+        compilerOptions !== undefined ? getCompilerFlags(compilerOptions) : [];
       const compilerFlags = [
         id,
         "--outFile",
@@ -158,13 +109,7 @@ export default function useWasm(options?: PluginOptions): Plugin {
         sourceMapPath,
         "--bindings",
         "esm",
-        "-Ospeed",
-        "--noAssert",
-        "--converge",
-        "--optimize",
-        ...(compilerOptions !== undefined
-          ? getCompilerFlags(compilerOptions)
-          : []),
+        ...userDefinedFlags,
       ];
 
       try {

--- a/packages/vite-plugin-use-wasm/src/options.ts
+++ b/packages/vite-plugin-use-wasm/src/options.ts
@@ -1,0 +1,130 @@
+/**
+ * AssemblyScript compiler options that can be passed to the AssemblyScript compiler.
+ * These options control how the AssemblyScript code is compiled to WebAssembly.
+ */
+export interface AssemblyScriptOptions {
+  /**
+   * Enable optimization of the generated WebAssembly module.
+   * When enabled, produces smaller and faster WebAssembly code.
+   * @default undefined (uses AssemblyScript default)
+   */
+  optimize?: boolean;
+
+  /**
+   * Set the optimization level (0-3).
+   * Higher levels increase compilation time but may yield better performance.
+   * @default undefined (uses AssemblyScript default)
+   */
+  optimizeLevel?: 0 | 1 | 2 | 3;
+
+  /**
+   * Set the size optimization level (0-3).
+   * Higher levels prioritize smaller code size over speed.
+   * @default undefined (uses AssemblyScript default)
+   */
+  shrinkLevel?: 0 | 1 | 2;
+
+  /**
+   * Re-optimizes until no further improvements can be made.
+   * @default undefined (uses AssemblyScript default)
+   */
+  converge?: boolean;
+
+  /**
+   * Replaces assertions with just their value without trapping.
+   * @default undefined (uses AssemblyScript default)
+   */
+  noAssert?: boolean;
+
+  /**
+   * Specify the runtime variant to use.
+   * - "incremental": Full garbage collector with incremental collection
+   * - "minimal": Minimal runtime with basic memory management
+   * - "stub": Stub runtime for maximum performance (no GC)
+   * @default undefined (uses AssemblyScript default)
+   */
+  runtime?: "incremental" | "minimal" | "stub";
+
+  /**
+   * Export the runtime helpers to allow manual memory management.
+   * Useful when you need direct access to memory allocation functions.
+   * @default undefined (uses AssemblyScript default)
+   */
+  exportRuntime?: boolean;
+
+  /**
+   * Import memory from the host environment instead of creating it.
+   * Allows sharing memory between multiple WebAssembly modules.
+   * @default undefined (uses AssemblyScript default)
+   */
+  importMemory?: boolean;
+
+  /**
+   * Initial memory size in WebAssembly pages (64KB each).
+   * Sets the minimum amount of memory the module will have available.
+   * @default undefined (uses AssemblyScript default of 0)
+   */
+  initialMemory?: number;
+
+  /**
+   * Maximum memory size in WebAssembly pages (64KB each).
+   * Sets the upper limit for memory growth. Must be greater than initialMemory.
+   * @default undefined (allows unlimited growth up to WebAssembly limits)
+   */
+  maximumMemory?: number;
+
+  /**
+   * Enable shared memory support for multi-threading.
+   * Requires maximumMemory to be set and threads feature to be enabled.
+   * @default undefined (uses AssemblyScript default)
+   */
+  sharedMemory?: boolean;
+
+  /**
+   * Include debug information in the generated WebAssembly module.
+   * Useful for debugging but increases module size.
+   * @default undefined (uses AssemblyScript default)
+   */
+  debug?: boolean;
+}
+
+/**
+ * Configuration options for the vite-plugin-use-wasm plugin.
+ * Controls both the AssemblyScript compilation process and the plugin's behavior.
+ */
+export interface PluginOptions {
+  /**
+   * AssemblyScript compiler-specific options.
+   * These options are passed directly to the AssemblyScript compiler.
+   * @default undefined
+   */
+  compilerOptions?: AssemblyScriptOptions;
+
+  /**
+   * Whether to adapt the generated bindings for browser environments.
+   * When enabled, modifies imports/exports to be browser-compatible.
+   * @default true
+   */
+  browser?: boolean;
+
+  /**
+   * Whether to emit the WebAssembly text format (.wat) file as an asset.
+   * The .wat file is a human-readable representation of the WebAssembly module.
+   * @default false
+   */
+  emitWasmTextFile?: boolean;
+
+  /**
+   * Whether to emit TypeScript declaration (.d.ts) files as assets.
+   * Provides type definitions for the compiled WebAssembly module.
+   * @default true
+   */
+  emitDtsFile?: boolean;
+
+  /**
+   * Whether to emit source map (.map) files as assets.
+   * Enables debugging by mapping compiled code back to original source.
+   * @default false
+   */
+  emitSourceMap?: boolean;
+}

--- a/packages/vite-plugin-use-wasm/src/utils/compiler.ts
+++ b/packages/vite-plugin-use-wasm/src/utils/compiler.ts
@@ -1,0 +1,51 @@
+import type { AssemblyScriptOptions } from "../options";
+
+export function getCompilerFlags(options: AssemblyScriptOptions): string[] {
+  const flags: string[] = [];
+
+  if (options.optimize) {
+    flags.push("--optimize");
+  }
+
+  if (options.optimizeLevel !== undefined) {
+    flags.push("--optimizeLevel", options.optimizeLevel.toString());
+  }
+
+  if (options.shrinkLevel !== undefined) {
+    flags.push("--shrinkLevel", options.shrinkLevel.toString());
+  }
+
+  if (options.converge) {
+    flags.push("--converge");
+  }
+
+  if (options.noAssert) {
+    flags.push("--noAssert");
+  }
+
+  if (options.runtime) {
+    flags.push("--runtime", options.runtime);
+  }
+
+  if (options.importMemory) {
+    flags.push("--importMemory");
+  }
+
+  if (options.initialMemory) {
+    flags.push("--initialMemory", options.initialMemory.toString());
+  }
+
+  if (options.maximumMemory) {
+    flags.push("--maximumMemory", options.maximumMemory.toString());
+  }
+
+  if (options.sharedMemory) {
+    flags.push("--sharedMemory");
+  }
+
+  if (options.debug) {
+    flags.push("--debug");
+  }
+
+  return flags;
+}


### PR DESCRIPTION
This pull request introduces a more flexible and configurable way to use the `vite-plugin-use-wasm` plugin by adding comprehensive options for AssemblyScript compilation and asset emission. It refactors the plugin's API to accept a new `PluginOptions` interface, enables fine-grained control over compiler flags, and improves how assets are emitted based on user configuration. The changes also include improved test coverage and code organization.

**Plugin configuration and flexibility:**

* Added a new `PluginOptions` interface (in `options.ts`) that allows users to specify AssemblyScript compiler options (`compilerOptions`), and control emission of `.wat`, `.d.ts`, and source map files, as well as browser adaptation. (`[packages/vite-plugin-use-wasm/src/options.tsR1-R130](diffhunk://#diff-bb68a538397dc7f291104af15ff7be4f4f332ba3d58b517246eb75a32bcb77fcR1-R130)`)
* Refactored the main plugin entry point in `index.ts` to accept `PluginOptions`, and updated the plugin to use these options for controlling compilation and asset emission. (`[packages/vite-plugin-use-wasm/src/index.tsR20-L66](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7R20-L66)`)
* Moved and expanded the AssemblyScript compiler flags logic into a new utility function `getCompilerFlags` in `utils/compiler.ts`, supporting all relevant AssemblyScript options. (`[packages/vite-plugin-use-wasm/src/utils/compiler.tsR1-R51](diffhunk://#diff-d914e26efa131657488c21281bea373654d3d47ef6c7f716797b3ca14e269752R1-R51)`)

**Asset emission improvements:**

* Updated the plugin to conditionally emit `.wat`, `.d.ts`, and source map files based on the new options, and improved the logic for adapting bindings for browser or Node.js environments. (`[packages/vite-plugin-use-wasm/src/index.tsL204-R211](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L204-R211)`)
* Updated the example Vite config to demonstrate usage of the new options for `useWasm`. (`[examples/react-vite-ts/vite.config.tsL10-R25](diffhunk://#diff-96b8c7bc946e479ea01431b66a70cd7813b5c6bc986eccfe13cd8ae382888771L10-R25)`)

**Testing and code quality:**

* Adjusted tests to reflect new asset emission logic and updated code style for consistency. (`[[1]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL9)`, `[[2]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL28)`, `[[3]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL63-R61)`, `[[4]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL76)`, `[[5]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL106-R103)`, `[[6]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL126-R123)`, `[[7]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL145-R149)`, `[[8]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL165-R162)`, `[[9]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL189-R186)`, `[[10]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL201-R198)`, `[[11]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL213-R210)`, `[[12]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL226-R223)`)

These changes make the plugin much more configurable and robust for different build scenarios, improving both developer experience and output control.