### PR TITLE
fix: remove standalone folder when even when error

### DIFF
--- a/examples/react-vite-ts/vite.config.ts
+++ b/examples/react-vite-ts/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         shrinkLevel: 0,
         noAssert: true,
         converge: true,
-      }
+      },
     }),
     Inspect(),
     tailwindcss(),

--- a/packages/vite-plugin-use-wasm/src/constants/index.ts
+++ b/packages/vite-plugin-use-wasm/src/constants/index.ts
@@ -10,8 +10,10 @@ export const WASM_MODULE_DIRECTIVE = "use wasm";
 export const WASM_DIRECTIVE_REGEX = /^["']use wasm["'];?\s*/;
 export const BINDINGS_DEFAULT_WASM_URL_REGEX =
   /new URL\(".*?\.wasm", import\.meta\.url\)/g;
-export const STATIC_NODE_IMPORT_REGEX = /^import\s.+from\s+['"]node:[^'"]+['"];?\s*$/gm;
-export const NODE_BRANCH_REGEX = /const\s+isNodeOrBun\s*=.+?;\s*if\s*\(\s*isNodeOrBun\s*\)\s*\{\s*return\s+globalThis\.WebAssembly\.compile\([\s\S]*?import\(["']node:fs\/promises["']\)[\s\S]*?\);\s*\}\s*else\s*\{\s*return\s+await\s+globalThis\.WebAssembly\.compileStreaming\(globalThis\.fetch\(url\)\);\s*\}/ms;
+export const STATIC_NODE_IMPORT_REGEX =
+  /^import\s.+from\s+['"]node:[^'"]+['"];?\s*$/gm;
+export const NODE_BRANCH_REGEX =
+  /const\s+isNodeOrBun\s*=.+?;\s*if\s*\(\s*isNodeOrBun\s*\)\s*\{\s*return\s+globalThis\.WebAssembly\.compile\([\s\S]*?import\(["']node:fs\/promises["']\)[\s\S]*?\);\s*\}\s*else\s*\{\s*return\s+await\s+globalThis\.WebAssembly\.compileStreaming\(globalThis\.fetch\(url\)\);\s*\}/ms;
 export const DYNAMIC_NODE_IMPORT_REGEX = /import\(["']node:[^"']+["']\)/g;
 
 export const STANDALONE_ENVIRONMENT_FOLDER = ".use-wasm-temp";

--- a/packages/vite-plugin-use-wasm/src/index.ts
+++ b/packages/vite-plugin-use-wasm/src/index.ts
@@ -122,6 +122,7 @@ export default function useWasm(options?: PluginOptions): Plugin {
           throw error;
         }
       } catch (error) {
+        await standaloneEnvironment.clean();
         if (error instanceof Error) {
           throw new Error(
             `AssemblyScript compilation failed: ${error.message}`

--- a/packages/vite-plugin-use-wasm/src/index.ts
+++ b/packages/vite-plugin-use-wasm/src/index.ts
@@ -15,9 +15,9 @@ import {
   WASM_EXTENSION,
   WASM_TEXT_EXTENSION,
 } from "./constants";
+import type { PluginOptions } from "./options";
 import { StandaloneEnvironment } from "./utils";
 import { adaptBindingsForBrowser } from "./utils/browser";
-import type { PluginOptions } from "./options";
 import { getCompilerFlags } from "./utils/compiler";
 
 export default function useWasm(options?: PluginOptions): Plugin {
@@ -78,23 +78,23 @@ export default function useWasm(options?: PluginOptions): Plugin {
       await standaloneEnvironment.setup();
       const outFilePath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        wasmFileName
+        wasmFileName,
       );
       const textFilePath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        wasmTextFileName
+        wasmTextFileName,
       );
       const jsBindingsPath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        jsBindingsFileName
+        jsBindingsFileName,
       );
       const dTsPath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        dTsFileName
+        dTsFileName,
       );
       const sourceMapPath = path.join(
         standaloneEnvironment.standaloneOutputPath,
-        sourceMapFileName
+        sourceMapFileName,
       );
 
       const userDefinedFlags =
@@ -125,7 +125,7 @@ export default function useWasm(options?: PluginOptions): Plugin {
         await standaloneEnvironment.clean();
         if (error instanceof Error) {
           throw new Error(
-            `AssemblyScript compilation failed: ${error.message}`
+            `AssemblyScript compilation failed: ${error.message}`,
           );
         }
       }
@@ -154,7 +154,7 @@ export default function useWasm(options?: PluginOptions): Plugin {
 
         const devModeBindings = generatedBindings.replace(
           BINDINGS_DEFAULT_WASM_URL_REGEX,
-          `"${wasmDataUrl}"`
+          `"${wasmDataUrl}"`,
         );
 
         try {
@@ -211,7 +211,7 @@ export default function useWasm(options?: PluginOptions): Plugin {
           : generatedBindings;
         const resolvedBindings = tsBindings.replace(
           BINDINGS_DEFAULT_WASM_URL_REGEX,
-          `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`
+          `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`,
         );
         return {
           code: resolvedBindings,

--- a/packages/vite-plugin-use-wasm/src/utils/browser.ts
+++ b/packages/vite-plugin-use-wasm/src/utils/browser.ts
@@ -16,12 +16,12 @@ export function adaptBindingsForBrowser(code: string): string {
       const res = await globalThis.fetch(url);
       const bytes = await res.arrayBuffer();
       return await globalThis.WebAssembly.compile(bytes);
-    })()`
+    })()`,
   );
 
   out = out.replace(
     DYNAMIC_NODE_IMPORT_REGEX,
-    "Promise.reject(new Error('node: modules are unavailable in browser'))"
+    "Promise.reject(new Error('node: modules are unavailable in browser'))",
   );
 
   return out;

--- a/packages/vite-plugin-use-wasm/tests/plugin.test.ts
+++ b/packages/vite-plugin-use-wasm/tests/plugin.test.ts
@@ -58,7 +58,7 @@ function getTransformFn(plugin: ReturnType<typeof useWasm>["transform"]) {
   return plugin as unknown as (
     this: PluginContextMock,
     code: string,
-    id: string
+    id: string,
   ) => Promise<MinimalTransformResult | null>;
 }
 
@@ -100,7 +100,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       createPluginContext({ watchMode: false }),
       "export const x = 1;",
-      filePath
+      filePath,
     );
     expect(result).toBeNull();
   });
@@ -120,7 +120,7 @@ describe("vite-plugin-use-wasm", () => {
     expect(result.code).not.toContain("ROLLUP_FILE_URL_");
 
     const standaloneExists = await pathExists(
-      path.join(process.cwd(), STANDALONE_ENVIRONMENT_FOLDER)
+      path.join(process.cwd(), STANDALONE_ENVIRONMENT_FOLDER),
     );
     expect(standaloneExists).toBe(false);
   });
@@ -146,7 +146,7 @@ describe("vite-plugin-use-wasm", () => {
     expect(fileNames.some((n) => n.endsWith(".d.ts"))).toBe(true);
 
     const standaloneExists = await pathExists(
-      path.join(process.cwd(), STANDALONE_ENVIRONMENT_FOLDER)
+      path.join(process.cwd(), STANDALONE_ENVIRONMENT_FOLDER),
     );
     expect(standaloneExists).toBe(false);
   });
@@ -159,7 +159,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       ctx,
       SIMPLE_AS_CODE_SINGLE_QUOTE,
-      filePath
+      filePath,
     );
     expect(result).not.toBeNull();
     if (result === null) throw new Error("Expected result");
@@ -183,7 +183,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       ctx,
       DIRECTIVE_AT_END_SINGLE,
-      filePath
+      filePath,
     );
     expect(result).toBeNull();
   });
@@ -195,7 +195,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       createPluginContext({ watchMode: true }),
       DIRECTIVE_IN_FUNCTION_STRING,
-      filePath
+      filePath,
     );
     expect(result).toBeNull();
   });
@@ -207,7 +207,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       createPluginContext({ watchMode: true }),
       DIRECTIVE_AFTER_COMMENT,
-      filePath
+      filePath,
     );
     expect(result).toBeNull();
   });
@@ -220,7 +220,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       ctx,
       DIRECTIVE_WITH_LEADING_BLANKS,
-      filePath
+      filePath,
     );
     expect(result).not.toBeNull();
     if (result === null) throw new Error("Expected result");
@@ -235,7 +235,7 @@ describe("vite-plugin-use-wasm", () => {
     const result = await transformFn.call(
       ctx,
       DIRECTIVE_NO_SEMICOLON,
-      filePath
+      filePath,
     );
     expect(result).not.toBeNull();
     if (result === null) throw new Error("Expected result");
@@ -427,7 +427,7 @@ describe("vite-plugin-use-wasm", () => {
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toContain(
-          "AssemblyScript compilation failed"
+          "AssemblyScript compilation failed",
         );
       }
     });


### PR DESCRIPTION
This pull request primarily introduces code style improvements across several files in the `vite-plugin-use-wasm` package, focusing on consistent comma usage and minor formatting updates. Additionally, it adds a cleanup step to ensure temporary files are removed after failed AssemblyScript compilation attempts, improving resource management.

Code style and formatting consistency:

* Added trailing commas to function calls, object literals, and method parameters throughout `src/index.ts`, `src/utils/browser.ts`, and test files for improved readability and consistency. [[1]](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L81-R97) [[2]](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L156-R157) [[3]](diffhunk://#diff-e8aabbdc5e57ef0ce94d50d299df525ec467fa284e8fd9aecea3d2e17b34ace7L213-R214) [[4]](diffhunk://#diff-1a88b998f54eb2d135d56858bd055b975ebcd98666ced06ab1da8ad776a0b059L19-R24) [[5]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL61-R61) [[6]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL103-R103) [[7]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL123-R123) [[8]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL149-R149) [[9]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL162-R162) [[10]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL186-R186) [[11]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL198-R198) [[12]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL210-R210) [[13]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL223-R223) [[14]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL238-R238) [[15]](diffhunk://#diff-ab081d4bef6ad48310d2ede0f4522792b80b1bf47e76715afe5c346f0d68ac3fL430-R430) [[16]](diffhunk://#diff-96b8c7bc946e479ea01431b66a70cd7813b5c6bc986eccfe13cd8ae382888771L20-R20)
* Reformatted multi-line regular expression declarations for better readability in `src/constants/index.ts`.

Resource management improvement:

* Added a call to `standaloneEnvironment.clean()` in the error handling block of the AssemblyScript compilation process to ensure temporary files are cleaned up after compilation failures.

Import order adjustment:

* Moved the import of the `PluginOptions` type to the top of the import block in `src/index.ts` for consistency.